### PR TITLE
ci: add GitHub Actions CI pipeline (G8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: SafEye CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    name: Lint & Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+
+      - name: Lint with flake8
+        run: |
+          # Stop the build on syntax errors or undefined names
+          flake8 backend/ --count --select=E9,F63,F7,F82 --show-source --statistics
+          # Warnings as non-blocking (exit-zero)
+          flake8 backend/ --count --exit-zero --max-complexity=15 --max-line-length=120 --statistics
+
+      - name: Run tests (excluding slow model tests)
+        run: |
+          pytest tests/ -m "not slow" -v --tb=short
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
+
+  docker-build:
+    name: Docker Build Check
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t safeye:ci-test .
+
+      - name: Verify container starts
+        run: |
+          docker run -d --name safeye-test -p 7860:7860 safeye:ci-test
+          sleep 5
+          curl -f http://localhost:7860/api/health || exit 1
+          docker stop safeye-test


### PR DESCRIPTION
- Add ci.yml workflow triggered on push to main and PRs
- Run flake8 linting on backend/ (syntax errors block, style warnings don't)
- Run pytest excluding slow model-inference tests (@pytest.mark.slow)
- Test against Python 3.11 and 3.12 matrix
- Add Docker build verification step that builds image and checks /api/health endpoint responds
- Uses pip caching for faster CI runs
- Resolves roadmap gap G8 (no CI/CD pipeline)