### PR TITLE
chore: optimize Docker build context and add OCI labels

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,12 +37,22 @@ Thumbs.db
 uploads/*
 !uploads/.gitkeep
 data/*.json
-users.db
+*.db
 run_output.txt
 ngrok
 start-tunnel.sh
 deploy_package
 docs
+
+# AI Models (downloaded at runtime, ~500MB+)
+models/image_model/
+models/audio_model/
+models/text_model/
+models/bestdeepfake/
+
+# Tests (not needed in production image)
+tests/
+pytest.ini
 
 # Frontend source (built separately)
 src
@@ -53,3 +63,8 @@ tailwind.config.js
 postcss.config.js
 tsconfig*.json
 package*.json
+
+# Environment files
+.env
+.env.local
+.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,9 @@ FROM python:3.11-slim AS runtime
 
 LABEL maintainer="SafEye Team" \
       version="3.1.0" \
-      description="SafEye — AI-powered deepfake and misinformation detection"
+      description="SafEye — AI-powered deepfake and misinformation detection" \
+      org.opencontainers.image.source="https://github.com/Vicmuratha/NIRU-HACKATHON" \
+      org.opencontainers.image.licenses="MIT"
 
 # Runtime system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
Reduces Docker build context size by ~500MB+ and improves security.

### .dockerignore changes
| Added | Why |
|-------|-----|
| `models/image_model/`, `models/audio_model/`, etc. | ~500MB of model weights excluded — downloaded at runtime via `DOWNLOAD_MODELS_ON_STARTUP` |
| `*.db` | Exclude all dev databases (was only `users.db`) |
| `tests/`, `pytest.ini` | Not needed in production image |
| `.env`, `.env.local`, `.env.example` | Prevent secrets leaking into image layers |

### Dockerfile
- Added OCI-standard labels (`org.opencontainers.image.source`, `org.opencontainers.image.licenses`) for container registry metadata

Closes #28