### PR TITLE
feat: add X-Request-ID tracing to middleware

### DIFF
--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -5,6 +5,7 @@ Production-grade security headers, rate limiting, input validation, and request 
 
 import os
 import time
+import uuid
 import logging
 import hashlib
 from datetime import datetime
@@ -166,17 +167,23 @@ def validate_json_body(*required_fields: str):
 # ═══════════════════════════════════════════════════════════
 
 def log_request():
-    """Record request start time for latency tracking."""
+    """Record request start time and assign a unique request ID for tracing."""
     g.request_start = time.time()
+    # Use client-provided ID or generate a new UUID4
+    g.request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
 
 
 def log_response(response):
-    """Log request completion with latency."""
+    """Log request completion with latency and attach X-Request-ID header."""
+    request_id = getattr(g, "request_id", str(uuid.uuid4()))
+    response.headers["X-Request-ID"] = request_id
+
     duration = time.time() - getattr(g, "request_start", time.time())
     if request.path.startswith("/api/"):
         logger.info(
             "request_completed",
             extra={
+                "request_id": request_id,
                 "method": request.method,
                 "path": request.path,
                 "status": response.status_code,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -193,6 +193,20 @@ class TestSecurityHeaders:
         # Server header should be removed by middleware
         assert 'Server' not in resp.headers or 'Flask' not in resp.headers.get('Server', '')
 
+    def test_request_id_header_generated(self, client):
+        """Every response must include an X-Request-ID (UUID4) header."""
+        resp = client.get('/api/health')
+        rid = resp.headers.get('X-Request-ID')
+        assert rid is not None, "X-Request-ID header missing"
+        # Validate it is a proper UUID
+        uuid.UUID(rid, version=4)
+
+    def test_request_id_echo(self, client):
+        """If the client sends X-Request-ID, the server echoes it back."""
+        custom_id = str(uuid.uuid4())
+        resp = client.get('/api/health', headers={'X-Request-ID': custom_id})
+        assert resp.headers.get('X-Request-ID') == custom_id
+
 
 # ═══════════════════════════════════════════════════════════
 #  SIGNUP & LOGIN FLOWS


### PR DESCRIPTION
## Summary
Adds request ID tracing to every API response for production debugging.

### Changes
- **backend/middleware.py**: Generate UUID4 per request, store in `g.request_id`, attach as `X-Request-ID` response header. Honour client-provided ID for distributed tracing. Include `request_id` in structured log output.
- **tests/test_api.py**: 2 new tests — auto-generated ID validation + client echo verification.

### Testing
```bash
pytest tests/test_api.py::TestSecurityHeaders -v  # 4/4 passed
```

Closes #33