### PR TITLE
fix: sanitize text inputs to strip HTML/script tags

### DIFF
--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -4,6 +4,7 @@ Production-grade security headers, rate limiting, input validation, and request 
 """
 
 import os
+import re
 import time
 import uuid
 import logging
@@ -146,9 +147,34 @@ def validate_file_upload(field: str = "file", allowed_extensions: set | None = N
     return file, None
 
 
-def validate_json_body(*required_fields: str):
+# ── Text sanitization ──────────────────────────────────────
+
+# Compiled once for performance
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_SCRIPT_BLOCK_RE = re.compile(r"<script[\s\S]*?</script>", re.IGNORECASE)
+_STYLE_BLOCK_RE = re.compile(r"<style[\s\S]*?</style>", re.IGNORECASE)
+_EVENT_HANDLER_RE = re.compile(r"\bon\w+\s*=", re.IGNORECASE)
+
+
+def sanitize_text(text: str) -> str:
+    """
+    Strip HTML tags, <script>/<style> blocks, and inline event handlers
+    from user-supplied text to prevent stored-XSS and log injection.
+    """
+    if not isinstance(text, str):
+        return text
+    text = _SCRIPT_BLOCK_RE.sub("", text)
+    text = _STYLE_BLOCK_RE.sub("", text)
+    text = _HTML_TAG_RE.sub("", text)
+    text = _EVENT_HANDLER_RE.sub("", text)
+    return text.strip()
+
+
+def validate_json_body(*required_fields: str, sanitize: bool = True):
     """
     Validate that the request body is JSON and contains the required fields.
+    When *sanitize* is True (default), string values in the required fields
+    are run through sanitize_text() to strip HTML/script content.
     Returns (data, error_response).
     """
     data = request.get_json(silent=True)
@@ -158,6 +184,11 @@ def validate_json_body(*required_fields: str):
     missing = [f for f in required_fields if not data.get(f)]
     if missing:
         return None, (jsonify({"error": f"Missing required fields: {', '.join(missing)}"}), 400)
+
+    if sanitize:
+        for field in required_fields:
+            if isinstance(data.get(field), str):
+                data[field] = sanitize_text(data[field])
 
     return data, None
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -398,3 +398,35 @@ class TestEdgeCases:
                           data=json.dumps({}),
                           content_type='application/json')
         assert resp.status_code == 400
+
+
+# ═══════════════════════════════════════════════════════════
+#  INPUT SANITIZATION
+# ═══════════════════════════════════════════════════════════
+
+class TestInputSanitization:
+    """Verify that HTML/script tags are stripped from text inputs."""
+
+    @pytest.mark.slow
+    def test_html_tags_stripped(self, client):
+        payload = {'text': '<b>Breaking</b> <i>news</i>: the earth is flat'}
+        resp = client.post('/api/analyze/text',
+                          data=json.dumps(payload),
+                          content_type='application/json')
+        # Should not 400 — tag text is still long enough after stripping
+        assert resp.status_code in (200, 500)  # 500 if model unavailable
+
+    @pytest.mark.slow
+    def test_script_tags_stripped(self, client):
+        payload = {'text': '<script>alert("xss")</script>Some real content here for analysis'}
+        resp = client.post('/api/analyze/text',
+                          data=json.dumps(payload),
+                          content_type='application/json')
+        assert resp.status_code in (200, 500)
+
+    def test_sanitize_text_function_directly(self):
+        from backend.middleware import sanitize_text
+        assert sanitize_text('<b>hello</b>') == 'hello'
+        assert sanitize_text('<script>alert(1)</script>world') == 'world'
+        assert 'onclick' not in sanitize_text('click onclick=alert(1)')
+        assert sanitize_text('  normal text  ') == 'normal text'


### PR DESCRIPTION
## Summary
Prevents stored-XSS and log injection by stripping HTML/script content from user-supplied text before analysis.

### Changes
- **backend/middleware.py**: Added `sanitize_text()` with compiled regex for `<script>`, `<style>`, HTML tags, and event handlers. Integrated into `validate_json_body()` — all required string fields are auto-sanitized.
- **tests/test_api.py**: 3 new tests (1 fast unit test + 2 slow integration tests).

### Testing
```bash
pytest tests/test_api.py -m 'not slow' -v  # 48/48 passed
```

Closes #35