### PR TITLE
feat: cache /api/health response for 30 seconds

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ Production-grade Flask application:
 
 import os
 import sqlite3
+import time
 import uuid
 import json
 import warnings
@@ -1542,12 +1543,23 @@ def serve_upload(filename):
 
 
 # ══════════════════════════════════════════════════════════════
-#  HEALTH CHECK
+#  HEALTH CHECK  (cached for 30 s to reduce model-status overhead)
 # ══════════════════════════════════════════════════════════════
+
+_health_cache: dict = {"data": None, "expires": 0.0}
+HEALTH_CACHE_TTL = int(os.getenv("HEALTH_CACHE_TTL", "30"))  # seconds
+
 
 @app.route('/api/health', methods=['GET'])
 def health():
-    return jsonify({
+    now = time.time()
+    if _health_cache["data"] is not None and now < _health_cache["expires"]:
+        resp = jsonify(_health_cache["data"])
+        resp.headers["X-Cache"] = "HIT"
+        resp.headers["Cache-Control"] = f"public, max-age={HEALTH_CACHE_TTL}"
+        return resp
+
+    payload = {
         'status': 'healthy',
         'timestamp': datetime.now(timezone.utc).isoformat(),
         'models': {
@@ -1568,7 +1580,15 @@ def health():
             'news_screenshot_detector': True,
             'audio_context': True,
         }
-    })
+    }
+
+    _health_cache["data"] = payload
+    _health_cache["expires"] = now + HEALTH_CACHE_TTL
+
+    resp = jsonify(payload)
+    resp.headers["X-Cache"] = "MISS"
+    resp.headers["Cache-Control"] = f"public, max-age={HEALTH_CACHE_TTL}"
+    return resp
 
 
 # ══════════════════════════════════════════════════════════════

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,6 +32,20 @@ class TestHealthEndpoint:
         assert modules['election_shield'] is True
         assert modules['whatsapp_checker'] is True
 
+    def test_health_cache_header_present(self, client):
+        """First call should be a cache MISS, second within TTL a HIT."""
+        # Reset the module-level cache so this test is deterministic
+        import app as _app
+        _app._health_cache["data"] = None
+        _app._health_cache["expires"] = 0.0
+
+        resp1 = client.get('/api/health')
+        assert resp1.headers.get('X-Cache') == 'MISS'
+        assert 'max-age' in resp1.headers.get('Cache-Control', '')
+
+        resp2 = client.get('/api/health')
+        assert resp2.headers.get('X-Cache') == 'HIT'
+
 
 # ═══════════════════════════════════════════════════════════
 #  AUTH API


### PR DESCRIPTION
## Summary
Adds TTL-based caching to the health endpoint to reduce model-status polling overhead.

### Changes
- **app.py**: 30-second in-memory cache for health payload (configurable via HEALTH_CACHE_TTL env var). Returns X-Cache: HIT/MISS and Cache-Control headers.
- **tests/test_api.py**: 1 new test verifying MISS→HIT cache transition.

### Testing
```
pytest tests/test_api.py::TestHealthEndpoint -v  # 4/4 passed
```

Closes #37