### PR TITLE
fix: add api_base_url to GitHub OAuth registration

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,6 +135,7 @@ if HAS_OAUTH:
         client_secret=os.getenv("GITHUB_CLIENT_SECRET"),
         access_token_url='https://github.com/login/oauth/access_token',
         authorize_url='https://github.com/login/oauth/authorize',
+        api_base_url='https://api.github.com/',
         client_kwargs={'scope': 'user:email'},
     )
 


### PR DESCRIPTION
## Summary
Fixes the GitHub OAuth callback 500 error caused by a missing `api_base_url` in the OAuth registration.

## Changes
- Added `api_base_url='https://api.github.com/'` to the `oauth.register()` call for GitHub in `app.py`

## Problem
When a user clicks "Login with GitHub", the OAuth flow redirects to GitHub successfully, but the callback fails with:
```
requests.exceptions.MissingSchema: Invalid URL 'user': No scheme supplied
```
This happens because `github.get('user')` cannot resolve the relative path without a base URL.

## Testing
- Verified the OAuth flow completes without errors after the fix

Closes #39