### PR TITLE
fix: add forgot-password and reset-password to Vite proxy config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,14 @@ export default defineConfig({
         target: BACKEND_URL,
         changeOrigin: true,
       },
+      '/forgot-password': {
+        target: BACKEND_URL,
+        changeOrigin: true,
+      },
+      '/reset-password': {
+        target: BACKEND_URL,
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
Adds missing Vite dev server proxy rules for `/forgot-password` and `/reset-password` routes. Fixes #45.

## Problem
Clicking 'Forgot password?' on localhost:3000 served the React SPA home page instead of forwarding to the Flask backend's forgot password form.

## Changes
- Add `/forgot-password` proxy entry in `vite.config.ts`
- Add `/reset-password` proxy entry in `vite.config.ts`

Fixes #45