### PR TITLE
fix: remove duplicate CREATE TABLE statement

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,17 +231,6 @@ def init_db():
             FOREIGN KEY (user_id) REFERENCES users(id)
         )
     ''')
-    db.execute('''
-        CREATE TABLE IF NOT EXISTS password_reset_tokens (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            token TEXT UNIQUE NOT NULL,
-            expires_at TIMESTAMP NOT NULL,
-            used INTEGER DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users(id)
-        )
-    ''')
 
     # ─── Migrate existing users table if needed ───
     cursor = db.execute("PRAGMA table_info(users)")


### PR DESCRIPTION
Removes duplicate `password_reset_tokens` CREATE TABLE block in `init_db()`. Fixes #47.